### PR TITLE
fix: explicitly request UID in FETCH options

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func doSession(imap *imapCredentials, mail *gmail.Service) error {
 				}
 
 				log.Printf(
-					"Importing message received by %s (UID %d, size %.1fK, folder %s)",
+					"Importing message received by %s (uid %d, size %.1fK, folder %s)",
 					imap.Username, msg.uid, float32(len(msg.contents))/1024, folder)
 
 				if err := msg.importToGmail(mail, labels...); err != nil {


### PR DESCRIPTION
Previously, UID field could be zero in some servers when fetching messages by sequence number, causing STORE operations to fail silently.