### PR TITLE
feat: ensure deterministic IDLE folder monitoring

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,10 +102,11 @@ func (c *config) writeTo(f *os.File) {
 
 // Information needed to connect to an IMAP server. Implicit TLS is mandatory.
 type imapCredentials struct {
-	Address  string
-	Username string
-	Password string
-	Folders  map[string][]string
+	Address     string
+	Username    string
+	Password    string
+	Folders     map[string][]string
+	WatchFolder string // folder to IDLE on; defaults to "INBOX" if empty
 }
 
 // Obtain access to the Gmail API, refreshing and saving access tokens if
@@ -189,12 +190,36 @@ func doSession(imap *imapCredentials, mail *gmail.Service) error {
 		}
 	}
 
+	// Determine which folder to IDLE on. It must always be the last folder
+	// selected before IDLE — an extra SELECT between the drain loop and IDLE
+	// causes some servers (e.g. free.fr) to stop sending push notifications.
+	// We achieve this by draining all other folders first and WatchFolder last,
+	// so no additional SELECT is needed after the loop.
+	watchFolder := imap.WatchFolder
+	if watchFolder == "" {
+		watchFolder = "INBOX"
+	}
+
+	// Build an ordered folder list: non-watch folders first, watch folder last.
+	type folderEntry struct {
+		name   string
+		labels []string
+	}
+	var orderedFolders []folderEntry
+	for folder, labels := range folders {
+		if folder != watchFolder {
+			orderedFolders = append(orderedFolders, folderEntry{folder, labels})
+		}
+	}
+	orderedFolders = append(orderedFolders, folderEntry{watchFolder, folders[watchFolder]})
+
 	for {
-		// Interrogate the inbox and retrieve and expunge everything inside.
-		for folder, labels := range folders {
+		// Interrogate each folder and retrieve and expunge everything inside.
+		// WatchFolder is always last so it remains selected when we enter IDLE.
+		for _, entry := range orderedFolders {
 			for {
 				inbox, err := client.
-					Select(folder, nil).
+					Select(entry.name, nil).
 					Wait()
 				if err != nil {
 					log.Printf("SELECT error: %v", err)
@@ -215,9 +240,9 @@ func doSession(imap *imapCredentials, mail *gmail.Service) error {
 
 				log.Printf(
 					"Importing message received by %s (uid %d, size %.1fK, folder %s)",
-					imap.Username, msg.uid, float32(len(msg.contents))/1024, folder)
+					imap.Username, msg.uid, float32(len(msg.contents))/1024, entry.name)
 
-				if err := msg.importToGmail(mail, labels...); err != nil {
+				if err := msg.importToGmail(mail, entry.labels...); err != nil {
 					return err
 				}
 
@@ -227,7 +252,7 @@ func doSession(imap *imapCredentials, mail *gmail.Service) error {
 			}
 		}
 
-		// Go back to sleep until the next mailbox update.
+		// WatchFolder is already selected — go straight to IDLE.
 		if err := doIdle(client, mailboxUpdate, maxPollTime); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the folder drain loop iterated over a Go map, whose iteration order is random. This caused the IMAP connection to be left selected on a random folder before entering IDLE, meaning new mail notifications were only received for whichever folder happened to be last — and only for 5-minute timer-driven polls otherwise.

Two changes are combined here:

- Add an optional WatchFolder field to imapCredentials. When set, this folder is used as the IDLE target; it defaults to "INBOX" if omitted, so existing configs require no changes.

- Reorder the drain loop so WatchFolder is always processed last. This ensures it is already selected when IDLE starts, with no extra SELECT in between. The extra SELECT was found to cause some IMAP servers (e.g. free.fr) to stop sending push notifications entirely, falling back silently to 5-minute polling.