### PR TITLE
Detect missing `code` parameter in pasted auth URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,7 +150,12 @@ func doRequestAuth(ctx context.Context, c *config) {
 		log.Fatalln("Unable to parse redirected URL:", err)
 	}
 
-	tokens, err := oa.Exchange(ctx, parsedURL.Query().Get("code"))
+	authCode := parsedURL.Query().Get("code")
+	if authCode == "" {
+		log.Fatalln("No 'code' in redirected URL:", parsedURL)
+	}
+
+	tokens, err := oa.Exchange(ctx, authCode)
 	if err != nil {
 		log.Fatalln("Unable to retrieve tokens from Google:", err)
 	}


### PR DESCRIPTION
Adds a slightly more useful error message if one pastes the wrong URL into turbogmailfy during auth.  

I ran into this, so find it helpful to blame the URL directly, vs indirectly by failing the exchange.  But I understand if you'd prefer to keep this code shorter.