### PR TITLE
Add send-test-emails.sh test script

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+hello.exe
+hello

--- a/tests/hello.go
+++ b/tests/hello.go
@@ -1,0 +1,6 @@
+// A simple "hello, world" that will generate a binary for attaching to an email that will trip GMail's attachment filters
+package main
+
+func main() {
+     print("Hello, World!\n")
+}

--- a/tests/send-test-emails.sh
+++ b/tests/send-test-emails.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# send-test-emails.sh <to-address>
+#
+# Send test emails to the given address so you can watch turbogmailify handle them.
+#
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <target-email>"
+    exit 1
+fi
+
+if ! swaks --version > /dev/null; then
+    echo "$0 requires 'swaks' to be installed.  See https://jetmore.org/john/code/swaks/"
+    exit 1
+fi
+
+cd $(dirname $0)
+
+TARGET="$1"
+BODY="This is a turbogmailify test email pushed through swaks."
+
+# Usage: <subject> [<swaks args> ...]
+function swaks_send () {
+    SUBJECT="$1"; shift
+    SERVER=${SERVER:-localhost}
+
+    echo "test \"$SUBJECT\" $*"
+    # Use implicit, default "from" address which may not be right.
+    swaks --silent --server $SERVER --to "$TARGET" --body "$BODY" --header "Subject: ${SUBJECT}" "$@"
+}
+
+# Test 1: basic email
+
+swaks_send "turbogmailify test: basic email"
+
+# Test 2: Attach a Windows executable (Gmail rejects email with such attachments).
+# Lie about the attachment name because many services reject sending ".exe" files, based on the name (so secure!)
+
+GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" hello.go
+
+swaks_send "turbogmailify test: now with native hello" --attach-name hello.exe.hidden --attach @./hello.exe
+
+# TODO: send a BCC'd email
+# TODO: send a spammy email (or add spam headers?)
+
+# Test N: send a final, normal email to be sure turbogmailify didn't get lost handling the above
+
+swaks_send "turbogmailify final: basic email to make sure not side-tracked"
+
+
+#eof


### PR DESCRIPTION
Send some test emails to a given address to watch turbogmailify import them.

One of the tests is of sending a Windows executable (which Gmail will reject), so add a simple hello.go for generating said executable.

Depends on `swaks` (most distros should have it available) to actually send email via localhost.  swaks lets me specify the name of the attachment.

My motivation for this test case is that I get spam with the kinds of attachments that Google doesn't allow to be uploaded.  See https://support.google.com/mail/answer/6590#zippy=%2Cmessages-that-have-attachments  Turbogmailify currently handles these by stopping the import.  But it means subsequent emails in the inbox won't be seen:
```
2026/04/01 15:06:16 Error uploading to Gmail: googleapi: Error 400: Invalid attachment. Please check https://support.google.com/mail/answer/6590., invalidArgument
```

The GMail POP3 importer (which I'm trying to migrate away from) handles this by sending me a one-time "we failed to import this sketchy email" as a placeholder, and then ignores this message going forward.

I have a change I'll send out that does something similar for Turbogmailify (it tracks the Message-IDs of rejected messages and skips sending them.)  Alternative solutions might be to move such emails to a separate folder on the source, or to just delete them.  There are also options for just logging about the message to stdout, or sending a placeholder email (or a summary mail for multiple rejections) in place of the rejected mails.

I'm happy to just keep the test to myself, but thought it was a good way to demonstrate the problematic emails (in case you're lucky enough to not get these spammy messages in the wild).